### PR TITLE
[FIX] Member, Chat 매핑 오류 수정

### DIFF
--- a/src/main/java/hongik/Todoing/domain/chat/domain/Chat.java
+++ b/src/main/java/hongik/Todoing/domain/chat/domain/Chat.java
@@ -27,11 +27,13 @@ public class Chat extends BaseEntity {
     private String message;
 
     @ManyToOne
-    @JoinColumn(name = "sender_id")
+    @JoinColumn(name = "member_id")
     private Member sender;
 
     @ManyToOne
     @JoinColumn(name = "community_id")
     private Community community;
+
+
 
 }

--- a/src/main/java/hongik/Todoing/domain/chat/domain/Chat.java
+++ b/src/main/java/hongik/Todoing/domain/chat/domain/Chat.java
@@ -27,13 +27,11 @@ public class Chat extends BaseEntity {
     private String message;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "sender_id")
     private Member sender;
 
     @ManyToOne
     @JoinColumn(name = "community_id")
     private Community community;
-
-
 
 }

--- a/src/main/java/hongik/Todoing/domain/member/domain/Member.java
+++ b/src/main/java/hongik/Todoing/domain/member/domain/Member.java
@@ -40,6 +40,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<CommunityMember> communityMembers;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "sender")
     private List<Chat> chats;
 }

--- a/src/main/java/hongik/Todoing/domain/member/domain/Member.java
+++ b/src/main/java/hongik/Todoing/domain/member/domain/Member.java
@@ -40,6 +40,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<CommunityMember> communityMembers;
 
-    @OneToMany(mappedBy = "sender")
+    @OneToMany(mappedBy = "member")
     private List<Chat> chats;
 }


### PR DESCRIPTION
Member 에서 name=sender로 통일
참고로!!!

<이름 수정 내용>
카테고리 -> label
User -> Member
Authentication -> Verification

추가로 prompt_input으로 period가 직접 들어오는 것보다 언제부터 언제까지 수행이 더 좋을 것 같아서 수정함.