### PR TITLE
feat: AOP

### DIFF
--- a/src/main/java/hongik/Todoing/domain/verification/service/VisionService.java
+++ b/src/main/java/hongik/Todoing/domain/verification/service/VisionService.java
@@ -2,6 +2,7 @@ package hongik.Todoing.domain.verification.service;
 
 import com.google.cloud.vision.v1.*;
 import com.google.protobuf.ByteString;
+import hongik.Todoing.global.common.AuditingAi.AuditingAI;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +16,7 @@ import java.util.List;
 public class VisionService {
 
     // 사진을 통한 글자 인증 api 호출기
+    @AuditingAI("사진을 통한 글자 인증 호출기")
     public List<EntityAnnotation> detectText(MultipartFile image) throws IOException {
         List<AnnotateImageRequest> requests = new ArrayList<>();
 
@@ -55,6 +57,7 @@ public class VisionService {
     }
 
     // 사진을 통한 객체 인식 - label 탐색기
+    @AuditingAI("사진을 통한 객체 인식 - label 탐색기")
     public List<EntityAnnotation> detectLabels(MultipartFile file) throws IOException {
         ByteString imgBytes = ByteString.readFrom(file.getInputStream());
 

--- a/src/main/java/hongik/Todoing/global/common/AuditingAi/AuditingAI.java
+++ b/src/main/java/hongik/Todoing/global/common/AuditingAi/AuditingAI.java
@@ -1,0 +1,12 @@
+package hongik.Todoing.global.common.AuditingAi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuditingAI {
+    String value() default "Todo 에 대한 인증을 시작합니다.";
+}

--- a/src/main/java/hongik/Todoing/global/common/AuditingAi/AuditingAIAop.java
+++ b/src/main/java/hongik/Todoing/global/common/AuditingAi/AuditingAIAop.java
@@ -1,0 +1,50 @@
+package hongik.Todoing.global.common.AuditingAi;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class AuditingAIAop {
+
+    @Around("@annotation(AuditingAI)")
+    public Object execute(ProceedingJoinPoint point, AuditingAI AuditingAI) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        Object result;
+        try {
+            result = point.proceed();
+        } catch (Throwable t) {
+            log.error("Error in AuditingAI: {}", t.getMessage());
+            throw t;
+        }
+
+        long end = System.currentTimeMillis();
+        long duration = end - start;
+
+        String method = point.getSignature().toShortString();
+        String user = getCurrentUsername();
+        String action = AuditingAI.value();
+
+        log.info("AuditingAI - Method: {}, User: {}, Action: {}, Duration: {} ms", method, user, action, duration);
+
+        return result;
+
+    }
+
+    private String getCurrentUsername() {
+        // 현재 로그인된 사용자의 이름
+        try {
+            return SecurityContextHolder.getContext()
+                    .getAuthentication()
+                    .getName();
+        } catch (Exception e) {
+            return "anonymousUser";
+        }
+    }
+}

--- a/src/main/java/hongik/Todoing/global/common/TimeTrace/TimeTrace.java
+++ b/src/main/java/hongik/Todoing/global/common/TimeTrace/TimeTrace.java
@@ -1,0 +1,11 @@
+package hongik.Todoing.global.common.TimeTrace;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeTrace {
+}

--- a/src/main/java/hongik/Todoing/global/common/TimeTrace/TimeTraceAop.java
+++ b/src/main/java/hongik/Todoing/global/common/TimeTrace/TimeTraceAop.java
@@ -1,0 +1,25 @@
+package hongik.Todoing.global.common.TimeTrace;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class TimeTraceAop {
+    @Around("target(org.springframework.data.jpa.repository.JpaRepository)")
+    public Object execute(ProceedingJoinPoint point) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        try {
+            return point.proceed();
+        } finally {
+            long finish = System.currentTimeMillis();
+            String methodName = point.getSignature().toShortString();
+            log.info("Method [{}] executed in {} ms", methodName, (finish - start));
+        }
+    }
+}


### PR DESCRIPTION
## 이슈 번호 #32 

## 구현 내용
- 로깅 시간 측정을 위한 aop를 구현하였습니다.
- 현재 query 문에서 발생하는 즉, jpaRepository에서 걸리는 시간에 대해 시간을 로그로 기록합니다.
- 또한 인증 중 외부 api를 사용하게 되는데 이 때 걸리는 시간을 로그에 적어 추후 모니터링 및 실패 분석을 위한 지표로 사용될 예정입니다.