### PR TITLE
#36 refactor/ member 과 Todo 도메인 깊은 참조 제거, facade 패턴 예시로 도입

### DIFF
--- a/src/main/java/hongik/Todoing/domain/friend/service/FriendService.java
+++ b/src/main/java/hongik/Todoing/domain/friend/service/FriendService.java
@@ -76,7 +76,7 @@ public class FriendService {
             throw new GeneralException(ErrorStatus.FRIEND_BLOCKED);
         }
 
-        List<Todo> todos = todoRepository.findByMember(target);
+        List<Todo> todos = todoRepository.findByMemberId(target.getId());
         return TodoConverter.toTodoDtoList(todos);
     }
 

--- a/src/main/java/hongik/Todoing/domain/label/repository/LabelRepository.java
+++ b/src/main/java/hongik/Todoing/domain/label/repository/LabelRepository.java
@@ -12,3 +12,23 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
     Optional<Label> findByLabelName(LabelType labelName);
     boolean existsByLabelName(LabelType labelType);
 }
+
+
+// aggregated ( 도메인 집합 )
+// 주문. --- 주문 아이템. -- 주문 옵션
+
+
+// entity
+
+
+// order
+//. @Eager ,, fecth
+// { prviate OrderItem items   }
+
+// 주문 --- 주문아이템 갯수를 수정.
+
+
+
+
+
+

--- a/src/main/java/hongik/Todoing/domain/todo/controller/TodoController.java
+++ b/src/main/java/hongik/Todoing/domain/todo/controller/TodoController.java
@@ -8,6 +8,7 @@ import hongik.Todoing.domain.todo.dto.request.ChatTodoCreateRequestDTO;
 import hongik.Todoing.domain.todo.dto.request.TodoCreateRequestDTO;
 import hongik.Todoing.domain.todo.dto.request.TodoUpdateRequestDTO;
 import hongik.Todoing.domain.todo.dto.response.TodoResponseDTO;
+import hongik.Todoing.domain.todo.facade.TodoUsecase;
 import hongik.Todoing.domain.todo.service.ChatTodoService;
 import hongik.Todoing.domain.todo.service.SelfTodoService;
 import hongik.Todoing.global.apiPayload.ApiResponse;
@@ -29,6 +30,7 @@ public class TodoController {
     private final SelfTodoService selfTodoService;
     private final ChatSessionService chatSessionService;
     private final ChatTodoService chatTodoService;
+    private final TodoUsecase todoUsecase;
 
     // 투두리스트 만들기 - self
     @Operation(summary = "투두리스트를 생성합니다.")
@@ -37,7 +39,7 @@ public class TodoController {
             @AuthenticationPrincipal PrincipalDetails principal,
             @RequestBody TodoCreateRequestDTO requestDTO
             ) {
-        selfTodoService.createTodo(principal.getMember(), requestDTO);
+        todoUsecase.createTodo(principal.getMember().getId(), requestDTO);
         return ApiResponse.onSuccess(null);
     }
 
@@ -48,7 +50,7 @@ public class TodoController {
             @AuthenticationPrincipal PrincipalDetails principal,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate date
             ) {
-        List<TodoResponseDTO> todos = selfTodoService.getTodosByDate(principal.getMember(), date);
+        List<TodoResponseDTO> todos = selfTodoService.getTodosByDate(principal.getMember().getId(), date);
         return ApiResponse.onSuccess(todos);
     }
 
@@ -60,7 +62,7 @@ public class TodoController {
             @AuthenticationPrincipal PrincipalDetails principal,
             @PathVariable Long todoId
     ) {
-        selfTodoService.deleteTodo(principal.getMember(), todoId);
+        selfTodoService.deleteTodo(principal.getMember().getId(), todoId);
         return ApiResponse.onSuccess(null);
     }
 
@@ -73,7 +75,7 @@ public class TodoController {
             @PathVariable Long todoId,
             @RequestBody TodoUpdateRequestDTO requestDTO
     ) {
-        selfTodoService.updateTodo(principal.getMember(), todoId, requestDTO);
+        selfTodoService.updateTodo(principal.getMember().getId(), todoId, requestDTO);
         return ApiResponse.onSuccess(null);
     }
 
@@ -84,7 +86,7 @@ public class TodoController {
             @AuthenticationPrincipal PrincipalDetails principal,
             @PathVariable Long todoId
     ) {
-        selfTodoService.toggleTodo(principal.getMember(), todoId);
+        selfTodoService.toggleTodo(principal.getMember().getId(), todoId);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/hongik/Todoing/domain/todo/domain/Todo.java
+++ b/src/main/java/hongik/Todoing/domain/todo/domain/Todo.java
@@ -35,9 +35,8 @@ public class Todo extends BaseEntity {
     private boolean isCompleted;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private Member member;
+    @Column(name = "user_id")
+    private Long memberId;
 
     @ManyToOne
     @JoinColumn(name = "label_id")
@@ -58,4 +57,9 @@ public class Todo extends BaseEntity {
         this.todoDate = todoDate;
         this.label = label;
     }
+
+
+    ///2.   @트랜잭션 의 길이가 길어진다.
+
+
 }

--- a/src/main/java/hongik/Todoing/domain/todo/facade/TodoUsecase.java
+++ b/src/main/java/hongik/Todoing/domain/todo/facade/TodoUsecase.java
@@ -1,0 +1,66 @@
+package hongik.Todoing.domain.todo.facade;
+
+
+import hongik.Todoing.domain.chat.dto.ChatSessionState;
+import hongik.Todoing.domain.label.domain.Label;
+import hongik.Todoing.domain.label.repository.LabelRepository;
+import hongik.Todoing.domain.member.domain.Member;
+import hongik.Todoing.domain.member.service.MemberService;
+import hongik.Todoing.domain.todo.dto.request.ChatTodoCreateRequestDTO;
+import hongik.Todoing.domain.todo.dto.request.TodoCreateRequestDTO;
+import hongik.Todoing.domain.todo.service.SelfTodoService;
+import hongik.Todoing.global.apiPayload.code.status.ErrorStatus;
+import hongik.Todoing.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoUsecase {
+
+    private final SelfTodoService  selfTodoService;
+    private final MemberService memberService;
+    private final LabelRepository labelRepository;
+
+
+
+    // 멤버삭제
+    // 챗, 튜듀,
+    // delete use facade 만들어서.
+
+    // 기다린게 목적 x 도메인간의 참조를 끊어내는 거임.
+    // 스프링 이벤트는 어플리테이서ㅕㄴ이 다운되면,사라자미.
+    // 멤버 도메인 서비스에서 userDeleteEvent 발행.
+    // 각 도매인 서비스에서 리스닝.
+
+    // 면접보다가. 성능 개선. 개선한다면 어떻게 하실거에요?
+
+    // 큐가 계속 남아있다 . 제 3자
+    // mq messege queue ex ) kafka, rabbitmq
+
+
+    /**
+     * 절차지향 적인 Process 를 나타낼 수 있음.
+     * @param request
+     */
+
+    @Transactional
+    public void createTodo(Long memberId,TodoCreateRequestDTO request){
+
+        // 라벨을 찾고
+        Label label = labelRepository.findByLabelName(request.labelType())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        // 튜두를 만든다.
+        selfTodoService.createTodo(
+                memberId,
+                request.content(),
+                request.todoDate(),
+                label,
+                request.isAiNeeded()
+        );
+    }
+
+}

--- a/src/main/java/hongik/Todoing/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/hongik/Todoing/domain/todo/repository/TodoRepository.java
@@ -11,16 +11,17 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-    List<Todo> findByMember(Member member);
+
+    List<Todo> findByMemberId(Long memberId);
 
     Optional<Todo> findByTodoId(Long todoId);
 
     // todo 볼 때 라벨별로 봐야 함.
     @Query("""
-        SELECT t
-        FROM Todo t
-        WHERE t.member = :member AND t.todoDate = :date
-        ORDER BY t.label.labelName ASC
-        """)
-    List<Todo> findByMemberAndTodoDate(@Param("member") Member member,@Param("date") LocalDate date);
+    SELECT t
+    FROM Todo t
+    WHERE t.memberId = :memberId AND t.todoDate = :date
+    ORDER BY t.label.labelName ASC
+    """)
+    List<Todo> findByMemberIdAndTodoDate(@Param("memberId") Long memberId, @Param("date") LocalDate date);
 }

--- a/src/main/java/hongik/Todoing/domain/todo/service/ChatTodoService.java
+++ b/src/main/java/hongik/Todoing/domain/todo/service/ChatTodoService.java
@@ -35,7 +35,7 @@ public class ChatTodoService {
             for (ChatTodoCreateRequestDTO.SubQuest subQuest : requestDTO.getSubQuests()) {
                 System.out.println("📌 SubQuest: task=" + subQuest.getTask() + ", date=" + subQuest.getDate());
                 Todo todo = Todo.builder()
-                        .member(member)
+                        .memberId(member.getId())
                         .content(subQuest.getTask())
                         .todoDate(LocalDate.parse(subQuest.getDate()))
                         .label(label)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,4 @@ spring:
   profiles:
     active:
       - dev
+


### PR DESCRIPTION
---
name: PR_TEMPLATE
about: pull request 를 위한 템플
title: ''
labels: ''
assignees: ''

---

## 📌 작업 내용
- member 도메인과 todo 도메인의 깊은 객체 참조 제거
- facade(usecase) 패턴 도입하여 의존성 분리 예시 적용

## 🔍 주요 변경 사항
- Todo 엔티티에서 Member 객체 참조 제거 (`memberId`만 유지)
- TodoRepository 메서드 수정: `findByMember → findByMemberId`
- `ChatUsecase`, `TodoUsecase` 등 facade 계층 추가
- SelfTodoService는 Todo 도메인 조작만 책임지도록 분리

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동
- [ ] 관련 이슈 연결 (ex. #23)
- [ ] 커밋 메시지 규칙 준수
